### PR TITLE
Fixed AngleToString method

### DIFF
--- a/src/BurgerMonkeys.Tools/Converters/Angle.cs
+++ b/src/BurgerMonkeys.Tools/Converters/Angle.cs
@@ -90,7 +90,7 @@ namespace BurgerMonkeys.Tools
 
             try
             {
-                var v = Convert.ToDecimal(value);
+                var v = (decimal)value.ToString().AngleToDecimal();
                 var isPositive = v >= 0;
                 v = Math.Abs(v);
                 var deg = Math.Floor(v);


### PR DESCRIPTION
Now the last test pass. This occurs because of `System.Converter` doesn't works with `º` notation.